### PR TITLE
Fix division symbol in Lecture 0

### DIFF
--- a/lectures/lecture00.Rmd
+++ b/lectures/lecture00.Rmd
@@ -256,7 +256,7 @@ it were an R chunk, even though it is not really one. -->
 
 ## Trying out the REPL
 
-We will use exercises in the slides like a REPL. Use the math operations `*`, `\`, `+`, and `-` to compute twice the difference of 100 and 18. You can use `()` to group calculations.
+We will use exercises in the slides like a REPL. Use the math operations `*`, `/`, `+`, and `-` to compute twice the difference of 100 and 18. You can use `()` to group calculations.
 
 ```{r repl, exercise = TRUE, exercise.lines = 3}
 


### PR DESCRIPTION
In the section that talks about the available math operators, the division symbol should be the forward slash but instead is shown as the back slash.